### PR TITLE
Implement site-wide typography and navigation redesign

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -22,7 +22,7 @@
                     <span class="uppercase text-amber-100/80">Hi-End • El Yapımı • Kişiye Özel</span>
                 </span>
 
-                <h1 class="mt-6 text-4xl sm:text-6xl font-semibold tracking-tight leading-tight">
+                <h1 class="title-font mt-6 text-4xl sm:text-6xl font-bold leading-tight">
                     Mirror Acoustics
                 </h1>
 
@@ -62,7 +62,7 @@
     <!-- ÖZELLİKLER -->
     <section id="features" class="relative py-16 sm:py-20">
         <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <h2 class="text-center text-2xl sm:text-3xl font-semibold text-amber-900 dark:text-amber-200">Öne Çıkan
+            <h2 class="title-font text-center text-2xl sm:text-3xl font-bold text-amber-900 dark:text-amber-200">Öne Çıkan
                 Özellikler</h2>
             <p class="mx-auto mt-3 max-w-2xl text-center text-neutral-600 dark:text-neutral-300">
                 Her detayda kişiselleştirme ve üst düzey akustik performans.
@@ -115,7 +115,7 @@
     <section id="about" class="relative bg-neutral-50 py-16 sm:py-20 dark:bg-neutral-950">
         <div class="mx-auto grid max-w-6xl grid-cols-1 items-center gap-8 px-4 sm:px-6 lg:grid-cols-2 lg:px-8">
             <div class="relative order-2 lg:order-1">
-                <h2 class="text-2xl sm:text-3xl font-semibold text-amber-900 dark:text-amber-200">Hakkımızda</h2>
+                <h2 class="title-font text-2xl sm:text-3xl font-bold text-amber-900 dark:text-amber-200">Hakkımızda</h2>
                 <p class="mt-3 text-neutral-600 dark:text-neutral-300">
                     Mirror Acoustics, müziğin doğal ve saf hâlini sunmak için el yapımı hoparlör sistemleri üretir.
                     Her detayda kalite ve kişiselleştirme ön plandadır.
@@ -148,7 +148,7 @@
     <!-- VİTRİN -->
     <section id="featured" class="relative py-16 sm:py-20" th:if="${featured != null and !featured.empty}">
         <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-            <h2 class="text-center text-2xl sm:text-3xl font-semibold text-amber-900 dark:text-amber-200">Vitrin</h2>
+            <h2 class="title-font text-center text-2xl sm:text-3xl font-bold text-amber-900 dark:text-amber-200">Vitrin</h2>
             <p class="mx-auto mt-3 max-w-2xl text-center text-neutral-600 dark:text-neutral-300">
                 En beğenilen tasarımlarımızdan bir seçki.
             </p>
@@ -189,7 +189,7 @@
     <!-- ALT CTA -->
     <section id="cta" class="relative py-20">
         <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8 text-center">
-            <h2 class="text-2xl sm:text-3xl font-semibold text-amber-900 dark:text-amber-200">
+            <h2 class="title-font text-2xl sm:text-3xl font-bold text-amber-900 dark:text-amber-200">
                 Sesin Yansımasını Keşfet
             </h2>
             <p class="mt-3 text-neutral-600 dark:text-neutral-300">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -8,6 +8,11 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link th:href="@{/css/app.css}" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&family=Poppins:wght@300;400;500;600&display=swap"
+        rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -38,7 +43,11 @@
     </script>
     <style>
         body {
-            padding-top: 4.5rem;
+            font-family: 'Poppins', sans-serif;
+        }
+
+        .title-font {
+            font-family: 'Playfair Display', serif;
         }
 
         footer {
@@ -58,26 +67,24 @@
 </head>
 
 <body>
-    <header class="fixed-top">
-        <div class="bg-gradient-to-r from-amber-900 to-yellow-900/90 text-amber-50">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div class="flex h-16 items-center justify-between">
-                    <a th:href="@{/}" class="font-semibold tracking-wide text-amber-100 hover:text-white">Mirror Acoustics</a>
-                    <div class="flex items-center gap-6">
-                        <nav class="hidden md:flex items-center gap-6" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
-                            <a th:href="@{/}" class="hover:text-white/90">Ana Sayfa</a>
-                            <a th:href="@{/urun}" class="hover:text-white/90">Ürünler</a>
-                            <a th:href="@{|/cart?lang=${lang}|}" th:text="${lang=='en' ? 'Cart' : 'Sepet'}" class="hover:text-white/90">Sepet</a>
-                            <a sec:authorize="!isAuthenticated()" th:href="@{/admin/login}" class="hover:text-white/90">Admin</a>
-                            <a sec:authorize="isAuthenticated()" th:href="@{/admin/products}" class="hover:text-white/90">Yönetim</a>
-                            <form sec:authorize="isAuthenticated()" th:action="@{/admin/logout}" method="post">
-                                <button class="hover:text-white/90" type="submit">Çıkış</button>
-                            </form>
-                        </nav>
-                        <button type="button" onclick="themeToggle()" class="text-xl hover:text-white/90" aria-label="Tema değiştir">
-                            🌓
-                        </button>
-                    </div>
+    <header class="sticky top-0 z-50 bg-white dark:bg-gray-900 shadow-md">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex h-16 items-center justify-between">
+                <a th:href="@{/}" class="title-font text-2xl font-bold text-gray-800 dark:text-gray-100">MIRROR ACOUSTICS</a>
+                <div class="flex items-center gap-6">
+                    <nav class="hidden md:flex items-center space-x-8" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+                        <a th:href="@{/}" class="text-gray-800 hover:text-amber-600 dark:text-gray-100">Ana Sayfa</a>
+                        <a th:href="@{/urun}" class="text-gray-800 hover:text-amber-600 dark:text-gray-100">Ürünler</a>
+                        <a th:href="@{|/cart?lang=${lang}|}" th:text="${lang=='en' ? 'Cart' : 'Sepet'}" class="text-gray-800 hover:text-amber-600 dark:text-gray-100">Sepet</a>
+                        <a sec:authorize="!isAuthenticated()" th:href="@{/admin/login}" class="text-gray-800 hover:text-amber-600 dark:text-gray-100">Admin</a>
+                        <a sec:authorize="isAuthenticated()" th:href="@{/admin/products}" class="text-gray-800 hover:text-amber-600 dark:text-gray-100">Yönetim</a>
+                        <form sec:authorize="isAuthenticated()" th:action="@{/admin/logout}" method="post">
+                            <button class="text-gray-800 hover:text-amber-600 dark:text-gray-100" type="submit">Çıkış</button>
+                        </form>
+                    </nav>
+                    <button type="button" onclick="themeToggle()" class="text-xl text-gray-800 hover:text-amber-600 dark:text-gray-100" aria-label="Tema değiştir">
+                        🌓
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add Google Fonts and typography classes for Playfair Display and Poppins
- Replace gradient header with modern white navigation using new fonts
- Update home page headings to use title font for consistent branding

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/...)*
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b178c1cbe4832fa6d0b44f7b00d172