### PR TITLE
Fix index template to reference existing description fields

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -177,7 +177,7 @@
                         </div>
 
                         <p class="mt-1 line-clamp-2 text-sm text-neutral-600 dark:text-neutral-300"
-                            th:text="${lang=='en'? p.shortDescriptionEn : p.shortDescriptionTr}">
+                            th:text="${lang=='en'? p.descriptionEn : p.descriptionTr}">
                             Kısa açıklama…
                         </p>
                     </div>


### PR DESCRIPTION
## Summary
- display existing `descriptionEn` and `descriptionTr` in product list

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b187934832fba8346ffa6d0246b