### PR TITLE
feat: make homepage content editable

### DIFF
--- a/src/main/java/com/mertdev/mirror_acoustics/controller/AdminController.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/controller/AdminController.java
@@ -21,6 +21,7 @@ import com.mertdev.mirror_acoustics.domain.ProductImage;
 import com.mertdev.mirror_acoustics.repository.CategoryRepository;
 import com.mertdev.mirror_acoustics.repository.ProductRepository;
 import com.mertdev.mirror_acoustics.service.StorageService;
+import com.mertdev.mirror_acoustics.service.SettingService;
 import com.mertdev.mirror_acoustics.util.Slugger;
 
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class AdminController {
     private final ProductRepository repo;
     private final CategoryRepository categories;
     private final StorageService storage;
+    private final SettingService settings;
 
     @GetMapping("/login")
     public String login() {
@@ -127,5 +129,50 @@ public class AdminController {
         c.setSlug(Slugger.slugify(nameTr));
         categories.save(c);
         return "redirect:/admin/categories";
+    }
+
+    @GetMapping("/settings")
+    public String settingsForm(Model m) {
+        m.addAttribute("heroTitleTr", settings.get("hero.title", "tr"));
+        m.addAttribute("heroTitleEn", settings.get("hero.title", "en"));
+        m.addAttribute("heroSubtitleTr", settings.get("hero.subtitle", "tr"));
+        m.addAttribute("heroSubtitleEn", settings.get("hero.subtitle", "en"));
+        m.addAttribute("aboutTitleTr", settings.get("about.title", "tr"));
+        m.addAttribute("aboutTitleEn", settings.get("about.title", "en"));
+        m.addAttribute("aboutP1Tr", settings.get("about.p1", "tr"));
+        m.addAttribute("aboutP1En", settings.get("about.p1", "en"));
+        m.addAttribute("aboutP2Tr", settings.get("about.p2", "tr"));
+        m.addAttribute("aboutP2En", settings.get("about.p2", "en"));
+        m.addAttribute("contactAddressTr", settings.get("contact.address", "tr"));
+        m.addAttribute("contactAddressEn", settings.get("contact.address", "en"));
+        m.addAttribute("contactEmail", settings.get("contact.email", "tr"));
+        m.addAttribute("contactPhone", settings.get("contact.phone", "tr"));
+        return "admin/settings";
+    }
+
+    @PostMapping("/settings")
+    public String saveSettings(@RequestParam String heroTitleTr,
+            @RequestParam String heroTitleEn,
+            @RequestParam String heroSubtitleTr,
+            @RequestParam String heroSubtitleEn,
+            @RequestParam String aboutTitleTr,
+            @RequestParam String aboutTitleEn,
+            @RequestParam String aboutP1Tr,
+            @RequestParam String aboutP1En,
+            @RequestParam String aboutP2Tr,
+            @RequestParam String aboutP2En,
+            @RequestParam String contactAddressTr,
+            @RequestParam String contactAddressEn,
+            @RequestParam String contactEmail,
+            @RequestParam String contactPhone) {
+        settings.save("hero.title", heroTitleTr, heroTitleEn);
+        settings.save("hero.subtitle", heroSubtitleTr, heroSubtitleEn);
+        settings.save("about.title", aboutTitleTr, aboutTitleEn);
+        settings.save("about.p1", aboutP1Tr, aboutP1En);
+        settings.save("about.p2", aboutP2Tr, aboutP2En);
+        settings.save("contact.address", contactAddressTr, contactAddressEn);
+        settings.save("contact.email", contactEmail, contactEmail);
+        settings.save("contact.phone", contactPhone, contactPhone);
+        return "redirect:/admin/settings";
     }
 }

--- a/src/main/java/com/mertdev/mirror_acoustics/controller/HomeController.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/controller/HomeController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.mertdev.mirror_acoustics.service.ProductService;
+import com.mertdev.mirror_acoustics.service.SettingService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HomeController {
     private final ProductService products;
+    private final SettingService settings;
 
     @GetMapping({ "/", "/{lang:en|tr}" })
     public String index(@PathVariable(required = false) String lang,
@@ -22,6 +24,15 @@ public class HomeController {
         model.addAttribute("page", products.listActive(page, 8));
         model.addAttribute("featured", products.listFeatured(0, 6));
         model.addAttribute("lang", lang == null ? "tr" : lang);
+        String language = lang == null ? "tr" : lang;
+        model.addAttribute("heroTitle", settings.get("hero.title", language));
+        model.addAttribute("heroSubtitle", settings.get("hero.subtitle", language));
+        model.addAttribute("aboutTitle", settings.get("about.title", language));
+        model.addAttribute("aboutP1", settings.get("about.p1", language));
+        model.addAttribute("aboutP2", settings.get("about.p2", language));
+        model.addAttribute("contactAddress", settings.get("contact.address", language));
+        model.addAttribute("contactEmail", settings.get("contact.email", language));
+        model.addAttribute("contactPhone", settings.get("contact.phone", language));
         model.addAttribute("title", "Mirror Acoustics — Custom Audio Products");
         model.addAttribute("description", "El yapımı, kişiye özel hi‑end hoparlör kabinleri ve sistemler.");
         return "index";

--- a/src/main/java/com/mertdev/mirror_acoustics/domain/Setting.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/domain/Setting.java
@@ -1,0 +1,30 @@
+package com.mertdev.mirror_acoustics.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "settings")
+@Data
+@NoArgsConstructor
+public class Setting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String key;
+
+    @Column(length = 4000)
+    private String valueTr;
+
+    @Column(length = 4000)
+    private String valueEn;
+}
+

--- a/src/main/java/com/mertdev/mirror_acoustics/repository/SettingRepository.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/repository/SettingRepository.java
@@ -1,0 +1,12 @@
+package com.mertdev.mirror_acoustics.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mertdev.mirror_acoustics.domain.Setting;
+
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+    Optional<Setting> findByKey(String key);
+}
+

--- a/src/main/java/com/mertdev/mirror_acoustics/service/SettingService.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/service/SettingService.java
@@ -1,0 +1,44 @@
+package com.mertdev.mirror_acoustics.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.mertdev.mirror_acoustics.domain.Setting;
+import com.mertdev.mirror_acoustics.repository.SettingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SettingService {
+    private final SettingRepository repo;
+
+    public String get(String key, String lang) {
+        Optional<Setting> s = repo.findByKey(key);
+        if (s.isEmpty()) {
+            return "";
+        }
+        return "en".equals(lang) ? s.get().getValueEn() : s.get().getValueTr();
+    }
+
+    public Setting find(String key) {
+        return repo.findByKey(key).orElseGet(() -> {
+            Setting s = new Setting();
+            s.setKey(key);
+            return repo.save(s);
+        });
+    }
+
+    public void save(String key, String valueTr, String valueEn) {
+        Setting s = repo.findByKey(key).orElseGet(() -> {
+            Setting n = new Setting();
+            n.setKey(key);
+            return n;
+        });
+        s.setValueTr(valueTr);
+        s.setValueEn(valueEn);
+        repo.save(s);
+    }
+}
+

--- a/src/main/resources/templates/admin/settings.html
+++ b/src/main/resources/templates/admin/settings.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('Site Ayarları', ~{::content})}">
+<th:block th:fragment="content">
+    <h1 class="h3 mb-3">Site Ayarları</h1>
+    <form th:action="@{/admin/settings}" method="post" class="vstack gap-3">
+        <div>
+            <label class="form-label">Kahraman Başlığı (TR)</label>
+            <input class="form-control" name="heroTitleTr" th:value="${heroTitleTr}">
+        </div>
+        <div>
+            <label class="form-label">Hero Title (EN)</label>
+            <input class="form-control" name="heroTitleEn" th:value="${heroTitleEn}">
+        </div>
+        <div>
+            <label class="form-label">Kahraman Alt Başlığı (TR)</label>
+            <input class="form-control" name="heroSubtitleTr" th:value="${heroSubtitleTr}">
+        </div>
+        <div>
+            <label class="form-label">Hero Subtitle (EN)</label>
+            <input class="form-control" name="heroSubtitleEn" th:value="${heroSubtitleEn}">
+        </div>
+        <div>
+            <label class="form-label">Hakkımızda Başlığı (TR)</label>
+            <input class="form-control" name="aboutTitleTr" th:value="${aboutTitleTr}">
+        </div>
+        <div>
+            <label class="form-label">About Title (EN)</label>
+            <input class="form-control" name="aboutTitleEn" th:value="${aboutTitleEn}">
+        </div>
+        <div>
+            <label class="form-label">Hakkımızda Paragraf 1 (TR)</label>
+            <textarea class="form-control" name="aboutP1Tr" rows="3" th:text="${aboutP1Tr}"></textarea>
+        </div>
+        <div>
+            <label class="form-label">About Paragraph 1 (EN)</label>
+            <textarea class="form-control" name="aboutP1En" rows="3" th:text="${aboutP1En}"></textarea>
+        </div>
+        <div>
+            <label class="form-label">Hakkımızda Paragraf 2 (TR)</label>
+            <textarea class="form-control" name="aboutP2Tr" rows="3" th:text="${aboutP2Tr}"></textarea>
+        </div>
+        <div>
+            <label class="form-label">About Paragraph 2 (EN)</label>
+            <textarea class="form-control" name="aboutP2En" rows="3" th:text="${aboutP2En}"></textarea>
+        </div>
+        <div>
+            <label class="form-label">Adres (TR)</label>
+            <input class="form-control" name="contactAddressTr" th:value="${contactAddressTr}">
+        </div>
+        <div>
+            <label class="form-label">Address (EN)</label>
+            <input class="form-control" name="contactAddressEn" th:value="${contactAddressEn}">
+        </div>
+        <div>
+            <label class="form-label">Email</label>
+            <input class="form-control" name="contactEmail" th:value="${contactEmail}">
+        </div>
+        <div>
+            <label class="form-label">Telefon</label>
+            <input class="form-control" name="contactPhone" th:value="${contactPhone}">
+        </div>
+        <div class="mt-3">
+            <button type="submit" class="btn btn-primary">Kaydet</button>
+        </div>
+    </form>
+</th:block>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="tr">
+<html lang="tr" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -75,8 +75,8 @@
     <!-- Hero Section -->
     <section class="hero-section flex items-center justify-center text-white">
         <div class="container mx-auto px-6 text-center">
-            <h1 class="text-4xl md:text-6xl font-bold mb-6 title-font">Sanatla Yoğrulmuş Ses Deneyimi</h1>
-            <p class="text-xl md:text-2xl mb-8 max-w-3xl mx-auto">El yapımı, özel tasarım hoparlör sistemleri ile müziğin en saf halini yaşam alanlarınıza taşıyoruz.</p>
+            <h1 class="text-4xl md:text-6xl font-bold mb-6 title-font" th:text="${heroTitle}">Sanatla Yoğrulmuş Ses Deneyimi</h1>
+            <p class="text-xl md:text-2xl mb-8 max-w-3xl mx-auto" th:text="${heroSubtitle}">El yapımı, özel tasarım hoparlör sistemleri ile müziğin en saf halini yaşam alanlarınıza taşıyoruz.</p>
             <div class="flex flex-col md:flex-row justify-center gap-4">
                 <a href="#products" class="bg-amber-600 hover:bg-amber-700 text-white px-8 py-3 rounded-lg text-lg font-semibold transition">Ürünleri Keşfet</a>
                 <a href="#contact" class="bg-transparent hover:bg-white hover:text-gray-900 border-2 border-white text-white px-8 py-3 rounded-lg text-lg font-semibold transition">Bize Ulaşın</a>
@@ -89,9 +89,9 @@
         <div class="container mx-auto px-6">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-10 md:mb-0 md:pr-10">
-                    <h2 class="text-3xl md:text-4xl font-bold mb-6 title-font">Mirror Acoustics</h2>
-                    <p class="text-gray-700 mb-6">Mirror Acoustics, İstanbul merkezli bir atölyede İsmet Çataloğlu tarafından kurulmuş ve onun titiz çalışmalarıyla büyüyen özel bir ses sistemleri markasıdır. Her bir ürün, yüksek mühendislik bilgisi ile el işçiliğinin zarif birleşimini yansıtır.</p>
-                    <p class="text-gray-700 mb-6">Bizim için hoparlörler sadece birer elektronik cihaz değil, aynı zamanda sanat eseri ve yaşam alanlarınıza değer katan tasarımlardır. Seçtiğiniz ahşap türü ve özel tasarım talepleriniz doğrultusunda, tamamen kişiye özel hoparlör kabinleri ve sistemler üretiyoruz.</p>
+                    <h2 class="text-3xl md:text-4xl font-bold mb-6 title-font" th:text="${aboutTitle}">Mirror Acoustics</h2>
+                    <p class="text-gray-700 mb-6" th:text="${aboutP1}">Mirror Acoustics, İstanbul merkezli bir atölyede İsmet Çataloğlu tarafından kurulmuş ve onun titiz çalışmalarıyla büyüyen özel bir ses sistemleri markasıdır. Her bir ürün, yüksek mühendislik bilgisi ile el işçiliğinin zarif birleşimini yansıtır.</p>
+                    <p class="text-gray-700 mb-6" th:text="${aboutP2}">Bizim için hoparlörler sadece birer elektronik cihaz değil, aynı zamanda sanat eseri ve yaşam alanlarınıza değer katan tasarımlardır. Seçtiğiniz ahşap türü ve özel tasarım talepleriniz doğrultusunda, tamamen kişiye özel hoparlör kabinleri ve sistemler üretiyoruz.</p>
                     <div class="flex items-center mt-8">
                         <div class="bg-amber-100 p-4 rounded-full mr-4">
                             <i class="fas fa-medal text-amber-600 text-2xl"></i>
@@ -330,7 +330,7 @@
                                 </div>
                                 <div>
                                     <h4 class="font-bold text-lg mb-1">Adres</h4>
-                                    <p class="text-gray-700">Mirror Acoustics Custom Audio Products – İstanbul, Türkiye</p>
+                                    <p class="text-gray-700" th:text="${contactAddress}">Mirror Acoustics Custom Audio Products – İstanbul, Türkiye</p>
                                 </div>
                             </div>
                             <div class="flex items-start">
@@ -339,7 +339,7 @@
                                 </div>
                                 <div>
                                     <h4 class="font-bold text-lg mb-1">Email</h4>
-                                    <p class="text-gray-700">info@mirroracoustics.com</p>
+                                    <p class="text-gray-700" th:text="${contactEmail}">info@mirroracoustics.com</p>
                                 </div>
                             </div>
                             <div class="flex items-start">
@@ -348,7 +348,7 @@
                                 </div>
                                 <div>
                                     <h4 class="font-bold text-lg mb-1">Telefon</h4>
-                                    <p class="text-gray-700">+90 555 123 45 67</p>
+                                    <p class="text-gray-700" th:text="${contactPhone}">+90 555 123 45 67</p>
                                 </div>
                             </div>
                             <div class="pt-6">
@@ -420,13 +420,13 @@
                         <h4 class="text-lg font-semibold mb-4 title-font">İletişim</h4>
                         <ul class="space-y-2">
                             <li class="flex items-center text-gray-400">
-                                <i class="fas fa-map-marker-alt mr-2 text-amber-500"></i> İstanbul, Türkiye
+                                <i class="fas fa-map-marker-alt mr-2 text-amber-500"></i> <span th:text="${contactAddress}">İstanbul, Türkiye</span>
                             </li>
                             <li class="flex items-center text-gray-400">
-                                <i class="fas fa-phone-alt mr-2 text-amber-500"></i> +90 555 123 45 67
+                                <i class="fas fa-phone-alt mr-2 text-amber-500"></i> <span th:text="${contactPhone}">+90 555 123 45 67</span>
                             </li>
                             <li class="flex items-center text-gray-400">
-                                <i class="fas fa-envelope mr-2 text-amber-500"></i> info@mirroracoustics.com
+                                <i class="fas fa-envelope mr-2 text-amber-500"></i> <span th:text="${contactEmail}">info@mirroracoustics.com</span>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
## Summary
- add settings entity/service to persist editable site texts
- expose admin settings page for managing homepage copy
- render hero, about and contact sections from saved settings

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b17e517e1c832f9869634acb6ebd2c