### PR TITLE
Add WhatsApp ordering flow and informational pages

### DIFF
--- a/src/main/java/com/mertdev/mirror_acoustics/controller/CartController.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/controller/CartController.java
@@ -1,5 +1,8 @@
 package com.mertdev.mirror_acoustics.controller;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,8 +10,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.mertdev.mirror_acoustics.domain.Cart;
+import com.mertdev.mirror_acoustics.domain.CartItem;
 import com.mertdev.mirror_acoustics.domain.Product;
 import com.mertdev.mirror_acoustics.service.CartService;
+import com.mertdev.mirror_acoustics.service.OrderDraftService;
 import com.mertdev.mirror_acoustics.service.ProductService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class CartController {
     private final CartService cartService;
     private final ProductService productService;
+    private final OrderDraftService orderDraftService;
 
     @GetMapping
     public String view(@RequestParam(defaultValue = "tr") String lang, Model model) {
@@ -31,9 +38,13 @@ public class CartController {
     @PostMapping("/add")
     public String add(@RequestParam Long productId,
                       @RequestParam(defaultValue = "1") int qty,
-                      @RequestParam(defaultValue = "tr") String lang) {
+                      @RequestParam(defaultValue = "tr") String lang,
+                      @RequestParam(required = false) String redirect) {
         Product product = productService.getById(productId);
         cartService.addProduct(product, qty);
+        if ("whatsapp".equals(redirect)) {
+            return "redirect:/cart?lang=" + lang + "&whatsapp=1";
+        }
         return "redirect:/cart?lang=" + lang;
     }
 
@@ -42,5 +53,39 @@ public class CartController {
                          @RequestParam(defaultValue = "tr") String lang) {
         cartService.removeProduct(productId);
         return "redirect:/cart?lang=" + lang;
+    }
+
+    @PostMapping("/whatsapp")
+    public String whatsapp(@RequestParam String name,
+                           @RequestParam String phone,
+                           @RequestParam(required = false) String email,
+                           @RequestParam String address,
+                           @RequestParam(required = false) String shipping,
+                           @RequestParam(required = false) String note,
+                           @RequestParam(defaultValue = "tr") String lang) {
+        Cart cart = cartService.getCart();
+        orderDraftService.saveDraft(cart, name, phone, email, address, shipping, note, "utm_source=site&utm_medium=whatsapp&utm_campaign=order");
+
+        StringBuilder sb = new StringBuilder("Merhaba, sipariş vermek istiyorum:\n");
+        for (CartItem item : cart.getItems()) {
+            sb.append("- Ürün: ")
+              .append(lang.equals("en") ? item.getProduct().getTitleEn() : item.getProduct().getTitleTr())
+              .append(" | Adet: ").append(item.getQuantity())
+              .append(" | Fiyat: ").append(item.getProduct().getPrice())
+              .append("\n");
+        }
+        sb.append("Ara Toplam: ").append(cart.getTotal()).append("\n");
+        if (shipping != null && !shipping.isBlank()) {
+            sb.append("Kargo: ").append(shipping).append("\n");
+        }
+        sb.append("İsim: ").append(name).append("\n")
+          .append("Telefon: ").append(phone).append("\n")
+          .append("Adres: ").append(address);
+        if (note != null && !note.isBlank()) {
+            sb.append("\nNot: ").append(note);
+        }
+
+        String message = URLEncoder.encode(sb.toString(), StandardCharsets.UTF_8);
+        return "redirect:https://wa.me/905551112233?text=" + message + "&utm_source=site&utm_medium=whatsapp&utm_campaign=order";
     }
 }

--- a/src/main/java/com/mertdev/mirror_acoustics/controller/PageController.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/controller/PageController.java
@@ -1,0 +1,37 @@
+package com.mertdev.mirror_acoustics.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+    @GetMapping("/hakkimizda")
+    public String about() {
+        return "pages/about";
+    }
+
+    @GetMapping("/iletisim")
+    public String contact() {
+        return "pages/contact";
+    }
+
+    @GetMapping("/kvkk")
+    public String privacy() {
+        return "pages/privacy";
+    }
+
+    @GetMapping("/teslimat")
+    public String delivery() {
+        return "pages/delivery";
+    }
+
+    @GetMapping("/iade-degisim")
+    public String returns() {
+        return "pages/returns";
+    }
+
+    @GetMapping("/sss")
+    public String faq() {
+        return "pages/faq";
+    }
+}

--- a/src/main/java/com/mertdev/mirror_acoustics/controller/ProductController.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/controller/ProductController.java
@@ -48,11 +48,6 @@ public class ProductController {
         model.addAttribute("lang", lang);
         model.addAttribute("title", (lang.equals("en") ? p.getTitleEn() : p.getTitleTr()) + " — Mirror Acoustics");
         model.addAttribute("description", lang.equals("en") ? p.getDescriptionEn() : p.getDescriptionTr());
-        String whatsappMessage = URLEncoder.encode(
-                "Merhaba, " + (lang.equals("en") ? p.getTitleEn() : p.getTitleTr()) +
-                        " hakkında bilgi almak istiyorum",
-                StandardCharsets.UTF_8);
-        model.addAttribute("whatsappMessage", whatsappMessage);
         return "product-detail";
     }
 }

--- a/src/main/java/com/mertdev/mirror_acoustics/domain/OrderDraft.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/domain/OrderDraft.java
@@ -1,0 +1,43 @@
+package com.mertdev.mirror_acoustics.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Table(name = "order_drafts")
+@Data
+public class OrderDraft {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(columnDefinition = "TEXT")
+    private String cartSnapshot;
+
+    private String name;
+    private String phone;
+    private String email;
+
+    @Column(columnDefinition = "TEXT")
+    private String address;
+
+    private String shippingPreference;
+
+    @Column(columnDefinition = "TEXT")
+    private String note;
+
+    private String utm;
+
+    @Column(nullable = false)
+    private String status = "draft_whatsapp";
+}

--- a/src/main/java/com/mertdev/mirror_acoustics/repository/OrderDraftRepository.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/repository/OrderDraftRepository.java
@@ -1,0 +1,8 @@
+package com.mertdev.mirror_acoustics.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.mertdev.mirror_acoustics.domain.OrderDraft;
+
+public interface OrderDraftRepository extends JpaRepository<OrderDraft, Long> {
+}

--- a/src/main/java/com/mertdev/mirror_acoustics/service/OrderDraftService.java
+++ b/src/main/java/com/mertdev/mirror_acoustics/service/OrderDraftService.java
@@ -1,0 +1,36 @@
+package com.mertdev.mirror_acoustics.service;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mertdev.mirror_acoustics.domain.Cart;
+import com.mertdev.mirror_acoustics.domain.OrderDraft;
+import com.mertdev.mirror_acoustics.repository.OrderDraftRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderDraftService {
+    private final OrderDraftRepository repository;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public OrderDraft saveDraft(Cart cart, String name, String phone, String email,
+                                String address, String shipping, String note, String utm) {
+        OrderDraft draft = new OrderDraft();
+        try {
+            draft.setCartSnapshot(mapper.writeValueAsString(cart));
+        } catch (JsonProcessingException e) {
+            draft.setCartSnapshot("{}");
+        }
+        draft.setName(name);
+        draft.setPhone(phone);
+        draft.setEmail(email);
+        draft.setAddress(address);
+        draft.setShippingPreference(shipping);
+        draft.setNote(note);
+        draft.setUtm(utm);
+        return repository.save(draft);
+    }
+}

--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -34,6 +34,35 @@
                 <span th:text="${lang=='en' ? 'Total:' : 'Toplam:'}">Toplam:</span>
                 <span th:text="${cart.items.get(0).product.currency} + ' ' + ${#numbers.formatDecimal(cart.total, 1, 'POINT', 2, 'POINT')}">₺ 0,00</span>
             </div>
+
+            <form th:action="@{/cart/whatsapp}" method="post" class="mt-6 space-y-2">
+                <input type="hidden" name="lang" th:value="${lang}" />
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Name Surname' : 'Ad Soyad'}">Ad Soyad</label>
+                    <input type="text" name="name" required class="w-full rounded border p-2" />
+                </div>
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Phone' : 'Telefon'}">Telefon</label>
+                    <input type="text" name="phone" required class="w-full rounded border p-2" />
+                </div>
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Email' : 'E-posta'}">E-posta</label>
+                    <input type="email" name="email" class="w-full rounded border p-2" />
+                </div>
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Address' : 'Adres'}">Adres</label>
+                    <textarea name="address" required class="w-full rounded border p-2"></textarea>
+                </div>
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Shipping Preference' : 'Kargo Tercihi'}">Kargo Tercihi</label>
+                    <input type="text" name="shipping" class="w-full rounded border p-2" />
+                </div>
+                <div>
+                    <label class="block text-sm" th:text="${lang=='en' ? 'Note' : 'Not'}">Not</label>
+                    <textarea name="note" class="w-full rounded border p-2"></textarea>
+                </div>
+                <button type="submit" class="mt-4 w-full rounded bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-500" th:text="${lang=='en' ? 'Order via WhatsApp' : 'WhatsApp\'tan Toplu Sipariş'}">WhatsApp'tan Toplu Sipariş</button>
+            </form>
         </div>
     </section>
 </th:block>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -3,6 +3,9 @@
     <div class="right">
         <a th:href="@{/}">[[#{nav.home}]]</a>
         <a th:href="@{/urun}">[[#{nav.products}]]</a>
+        <a th:href="@{/cart}">Sepet</a>
+        <a th:href="@{/hakkimizda}">Hakkımızda</a>
+        <a th:href="@{/iletisim}">İletişim</a>
         <a th:href="@{/en}">EN</a>
         <a th:href="@{/}">TR</a>
     </div>

--- a/src/main/resources/templates/pages/about.html
+++ b/src/main/resources/templates/pages/about.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('Hakkımızda', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">Hakkımızda</h1>
+        <p>Bu sayfa şirketiniz hakkında bilgi vermek için örnek metin içermektedir.</p>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/contact.html
+++ b/src/main/resources/templates/pages/contact.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('İletişim', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">İletişim</h1>
+        <p>Sorularınız için bize e-posta gönderebilir veya WhatsApp üzerinden ulaşabilirsiniz.</p>
+        <a href="https://wa.me/905551112233" target="_blank" class="mt-4 inline-block rounded bg-green-600 px-4 py-2 text-white">WhatsApp Destek</a>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/delivery.html
+++ b/src/main/resources/templates/pages/delivery.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('Teslimat & Kargo', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">Teslimat & Kargo</h1>
+        <p>Ürünleriniz anlaşmalı kargo firmaları ile gönderilir. Teslimat süreleri ve ücretleri buradan özelleştirilebilir.</p>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/faq.html
+++ b/src/main/resources/templates/pages/faq.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('SSS', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">Sık Sorulan Sorular</h1>
+        <p>Bu alan müşteri sorularına cevap vermek için kullanılabilir.</p>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/privacy.html
+++ b/src/main/resources/templates/pages/privacy.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('KVKK & Gizlilik', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">KVKK & Gizlilik</h1>
+        <p>Bu metin kişisel verilerinizin nasıl işlendiğini açıklamak için örnek olarak hazırlanmıştır.</p>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/pages/returns.html
+++ b/src/main/resources/templates/pages/returns.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="tr" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout('İade & Değişim', ~{::content})}">
+<th:block th:fragment="content">
+    <section class="py-6">
+        <h1 class="text-2xl font-semibold text-amber-900 mb-4">İade & Değişim</h1>
+        <p>İade ve değişim politikalarınızı burada müşterilere açıklayabilirsiniz.</p>
+    </section>
+</th:block>
+</html>

--- a/src/main/resources/templates/product-detail.html
+++ b/src/main/resources/templates/product-detail.html
@@ -29,12 +29,13 @@
                     <input type="hidden" name="lang" th:value="${lang}" />
                     <button type="submit" class="px-4 py-2 bg-amber-900 text-amber-50 rounded hover:bg-amber-800" th:text="${lang=='en' ? 'Add to Cart' : 'Sepete Ekle'}">Sepete Ekle</button>
                 </form>
+                <form th:action="@{/cart/add}" method="post" class="mt-4">
+                    <input type="hidden" name="productId" th:value="${p.id}" />
+                    <input type="hidden" name="lang" th:value="${lang}" />
+                    <input type="hidden" name="redirect" value="whatsapp" />
+                    <button type="submit" class="w-full rounded bg-green-600 px-4 py-2 text-white hover:bg-green-500" th:text="${lang=='en' ? 'Order via WhatsApp' : 'WhatsApp\'tan Sipariş Ver'}">WhatsApp'tan Sipariş Ver</button>
+                </form>
             </div>
-            <a th:href="'https://wa.me/905555555555?text=' + ${whatsappMessage}"
-               target="_blank"
-               class="mt-4 block w-full rounded-full bg-green-500 px-4 py-2 text-center font-medium text-white shadow-lg transition hover:bg-green-600">
-                WhatsApp ile İletişime Geç
-            </a>
         </div>
     </div>
 </th:block>


### PR DESCRIPTION
## Summary
- implement WhatsApp cart checkout with order snapshot logging
- link products and cart to WhatsApp ordering buttons
- add basic About, Contact, KVKK, Delivery, Returns and FAQ pages with navigation

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b181c658e8832fa1ab22d77b3d97a2